### PR TITLE
Skip Markdown escaping in code blocks

### DIFF
--- a/internal/service/bot/dafault_handler_test.go
+++ b/internal/service/bot/dafault_handler_test.go
@@ -1,0 +1,28 @@
+package bot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEscapeMarkdownInlineCode(t *testing.T) {
+	t.Parallel()
+	input := "before _text_ `code_with_underscore` after."
+	expected := "before \\_text\\_ `code_with_underscore` after\\."
+	require.Equal(t, expected, escapeMarkdown(input))
+}
+
+func TestEscapeMarkdownFencedCode(t *testing.T) {
+	t.Parallel()
+	input := "before _text_\n```\nfenced_code_with_underscore\n```\nafter."
+	expected := "before \\_text\\_\n```\nfenced_code_with_underscore\n```\nafter\\."
+	require.Equal(t, expected, escapeMarkdown(input))
+}
+
+func TestEscapeMarkdownInlineAndFencedCode(t *testing.T) {
+	t.Parallel()
+	input := "escape _markdown_ `inline_code` and\n```\nfenced_code_with_underscore\n```\nfinish."
+	expected := "escape \\_markdown\\_ `inline_code` and\n```\nfenced_code_with_underscore\n```\nfinish\\."
+	require.Equal(t, expected, escapeMarkdown(input))
+}


### PR DESCRIPTION
## Summary
- avoid escaping Markdown inside inline and fenced code blocks
- add unit tests for new escaping logic

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6894fc781eac8325b4e753d43d646713